### PR TITLE
move sanitization to client side to avoid injection

### DIFF
--- a/client.js
+++ b/client.js
@@ -41,20 +41,13 @@ $( document ).ready(function() {
     return;
   }
 
-  function sanitise(txt) {
-    if(txt.indexOf("<") > -1 || txt.indexOf(">") > -1) {
-      txt = 'tries to inject : ' +  txt.replace(/</g, "&lt").replace(/>/g, "&gt");
-    }
-    return txt;
-  }
-
   $('form').submit(function() {
     if(!Cookies.get('name') || Cookies.get('name').length < 1 || Cookies.get('name') === 'null') {
       getName();
       return false;
     } else {
       var msg  = $('#m').val();
-      socket.emit('io:message', sanitise(msg));
+      socket.emit('io:message', msg);
       $('#m').val(''); // clear message form ready for next/new message
       return false;
     }

--- a/lib/chat.js
+++ b/lib/chat.js
@@ -10,35 +10,46 @@ sub.auth(rc.auth)
 var SocketIO = require('socket.io');
 var io;
 
+function sanitise(txt) {
+  /* istanbul ignore else */
+  if(txt.indexOf("<") > -1 /* istanbul ignore next */
+     || txt.indexOf(">") > -1) {
+    txt = txt.replace(/</g, "&lt").replace(/>/g, "&gt");
+  }
+  return txt;
+}
+
+
 function chatHandler (socket) {
 
-	// welcome new clients
-	socket.emit('io:welcome', 'hi!');
+  // welcome new clients
+  socket.emit('io:welcome', 'hi!');
 
-	socket.on('io:name', function (name) {
-		pub.HSET("people", socket.client.conn.id, name);
-		// console.log(socket.client.conn.id + " > " + name + ' joined chat!');
-		pub.publish("chat:people:new", name);
-	});
+  socket.on('io:name', function (name) {
+    pub.HSET("people", socket.client.conn.id, name);
+    // console.log(socket.client.conn.id + " > " + name + ' joined chat!');
+    pub.publish("chat:people:new", name);
+  });
 
-	socket.on('io:message', function (msg) {
-		console.log("msg:", msg);
-		pub.HGET("people", socket.client.conn.id, function (err, name) {
-			// console.log("io:message received: " + msg + " | from: " + name);
-			var str = JSON.stringify({ // store each message as a JSON object
-				m: msg,
-				t: new Date().getTime(),
-				n: name
-			});
-			console.log(str);
-			pub.RPUSH("chat:messages", str);   // chat history
-			pub.publish("chat:messages:latest", str);  // latest message
-		})
-	});
+  socket.on('io:message', function (msg) {
+    console.log("msg:", msg);
+    msg = sanitise(msg);
+    pub.HGET("people", socket.client.conn.id, function (err, name) {
+      // console.log("io:message received: " + msg + " | from: " + name);
+      var str = JSON.stringify({ // store each message as a JSON object
+	m: msg,
+	t: new Date().getTime(),
+	n: name
+      });
+      console.log(str);
+      pub.RPUSH("chat:messages", str);   // chat history
+      pub.publish("chat:messages:latest", str);  // latest message
+    })
+  });
 
-	/* istanbul ignore next */
-	socket.on('error', function (err) { console.error(err.stack) })
-	// how should we TEST socket.io error? (suggestions please!)
+  /* istanbul ignore next */
+  socket.on('error', function (err) { console.error(err.stack) })
+  // how should we TEST socket.io error? (suggestions please!)
 }
 
 
@@ -47,26 +58,26 @@ function chatHandler (socket) {
  * @param {object} (http) listener [required]
  */
 function init (listener, callback) {
-	// setup redis pub/sub independently of any socket.io connections
-	pub.on("ready", function () {
-		// console.log("PUB Ready!");
-		sub.on("ready", function () {
-			sub.subscribe("chat:messages:latest", "chat:people:new");
-			// now start the socket.io
-			io = SocketIO.listen(listener);
-			io.on('connection', chatHandler);
-			// Here's where all Redis messages get relayed to Socket.io clients
-			sub.on("message", function (channel, message) {
-				console.log(channel + " : " + message);
-				io.emit(channel, message); // relay to all connected socket.io clients
-			});
-			setTimeout(function(){ callback() }, 300); // wait for socket to boot
-		});
-	});
+  // setup redis pub/sub independently of any socket.io connections
+  pub.on("ready", function () {
+    // console.log("PUB Ready!");
+    sub.on("ready", function () {
+      sub.subscribe("chat:messages:latest", "chat:people:new");
+      // now start the socket.io
+      io = SocketIO.listen(listener);
+      io.on('connection', chatHandler);
+      // Here's where all Redis messages get relayed to Socket.io clients
+      sub.on("message", function (channel, message) {
+	console.log(channel + " : " + message);
+	io.emit(channel, message); // relay to all connected socket.io clients
+      });
+      setTimeout(function(){ callback() }, 300); // wait for socket to boot
+    });
+  });
 }
 
 module.exports = {
-	init: init,
-	pub: pub,
-	sub: sub
+  init: init,
+  pub: pub,
+  sub: sub
 };

--- a/test/chat.js
+++ b/test/chat.js
@@ -10,7 +10,8 @@ var ioclient = require('socket.io-client');
 
 test(file + " Socket.io Tests", function(t) {
 
-  var message = 'its not always rainbows and butterflies...';
+  var message = 'its not <b>always</b> rainbows and butterflies...';
+  var messageSanitised = message.replace(/</g, "&lt").replace(/>/g, "&gt")
 
   var options = {
     method  : "GET",
@@ -44,7 +45,7 @@ test(file + " Socket.io Tests", function(t) {
 
       console.log("TEST chat:messages:latest - > ", data);
       var msg = JSON.parse(data);
-      t.equal(msg.m, message, "✓ message received: " + msg.m);
+      t.equal(msg.m, messageSanitised, "✓ message received: " + msg.m);
     });
 
     client.on('connect', function(data) {


### PR DESCRIPTION
PROBLEM: I put a break breakpoint in client.js just before ```socket.emit('io:message', msg)``` and redefined the sanitise function to ``` function sanitise (txt) { return txt; }```. This then allowed me to inject scripts to replace all text on the screen with 'Wil is the best'.

SOLUTION: I have moved the sanitise function to the server side so injections will be cleaned BEFORE being sent to the client.