### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "hapi": "^9.0.3",
     "hiredis": "^0.4.1",
-    "inert": "^3.0.1",
     "redis": "^0.12.1",
     "socket.io": "^1.3.6",
     "socket.io-client": "^1.3.6"
@@ -47,13 +46,13 @@
   },
   "scripts": {
     "docs": "./node_modules/jsdoc/jsdoc.js ./lib/*.js",
-    "quick": "./node_modules/tape/bin/tape ./test/*.js",
+    "quick": "PORT=8000 ./node_modules/tape/bin/tape ./test/*.js",
     "test": "PORT=8000 ./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./test/*.js",
-    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./test/*.js && ./node_modules/.bin/istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+    "coverage": "PORT=8000 ./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./test/*.js && ./node_modules/.bin/istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
     "jshint": "./node_modules/jshint/bin/jshint -c .jshintrc --exclude-path .gitignore .",
     "codeclimate": "CODECLIMATE_REPO_TOKEN=8bdde2e5617587b59c481ef04b710d04a78a6469fcee71840d58da7a839dda6b ./node_modules/codeclimate-test-reporter/bin/codeclimate.js < ./coverage/lcov.info",
     "open-coverage": "open ./test/coverage.html",
-    "spec": "node ./node_modules/tape/bin/tape ./test/*.js | node_modules/tap-spec/bin/cmd.js",
+    "spec": "PORT=8000 node ./node_modules/tape/bin/tape ./test/*.js | node_modules/tap-spec/bin/cmd.js",
     "start": "PORT=8000 ./node_modules/.bin/nodemon ./server.js"
   },
   "pre-commit": [

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "hapi": "^9.0.3",
     "hiredis": "^0.4.1",
+    "inert": "^3.0.1",
     "redis": "^0.12.1",
     "socket.io": "^1.3.6",
     "socket.io-client": "^1.3.6"

--- a/package.json
+++ b/package.json
@@ -27,27 +27,28 @@
   },
   "homepage": "https://github.com/dwyl/hapi-socketio-redis-chat-example#readme",
   "dependencies": {
-    "hapi": "^8.6.x",
-    "hiredis": "^0.4.0",
+    "hapi": "^9.0.3",
+    "hiredis": "^0.4.1",
+    "inert": "^3.0.1",
     "redis": "^0.12.1",
-    "socket.io": "^1.3.5",
-    "socket.io-client": "^1.3.5"
+    "socket.io": "^1.3.6",
+    "socket.io-client": "^1.3.6"
   },
   "devDependencies": {
     "codeclimate-test-reporter": "0.1.0",
-    "decache": "^3.0.2",
-    "istanbul": "^0.3.17",
+    "decache": "^3.0.3",
+    "istanbul": "^0.3.18",
     "jsdoc": "^3.3.2",
     "jshint": "^2.8.0",
-    "nodemon": "^1.4.0",
-    "pre-commit": "1.0.10",
-    "tap-spec": "^4.0.2",
-    "tape": "^4.0.0"
+    "nodemon": "^1.4.1",
+    "pre-commit": "1.1.1",
+    "tap-spec": "^4.1.0",
+    "tape": "^4.2.0"
   },
   "scripts": {
     "docs": "./node_modules/jsdoc/jsdoc.js ./lib/*.js",
     "quick": "./node_modules/tape/bin/tape ./test/*.js",
-    "test": "./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./test/*.js",
+    "test": "PORT=8000 ./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./test/*.js",
     "coverage": "./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./test/*.js && ./node_modules/.bin/istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
     "jshint": "./node_modules/jshint/bin/jshint -c .jshintrc --exclude-path .gitignore .",
     "codeclimate": "CODECLIMATE_REPO_TOKEN=8bdde2e5617587b59c481ef04b710d04a78a6469fcee71840d58da7a839dda6b ./node_modules/codeclimate-test-reporter/bin/codeclimate.js < ./coverage/lcov.info",

--- a/server.js
+++ b/server.js
@@ -5,20 +5,22 @@ server.connection({
 	host: '0.0.0.0',
 	port: Number(process.env.PORT)
 });
+server.register(require('inert'), function () {
 
-server.route([
-  { method: 'GET', path: '/', handler: { file: "index.html" } },
-	// switch these two routes for a /static handler?
-  { method: 'GET', path: '/client.js', handler: { file: './client.js' } },
-  { method: 'GET', path: '/style.css', handler: { file: './style.css' } },
-  { method: 'GET', path: '/load',      handler: require('./lib/load_messages').load }
-]);
+	server.route([
+	  { method: 'GET', path: '/', handler: { file: "index.html" } },
+		// switch these two routes for a /static handler?
+	  { method: 'GET', path: '/client.js', handler: { file: './client.js' } },
+	  { method: 'GET', path: '/style.css', handler: { file: './style.css' } },
+	  { method: 'GET', path: '/load',      handler: require('./lib/load_messages').load }
+	]);
 
-server.start(function () {
-	require('./lib/chat').init(server.listener, function(){
-		console.log(process.env.REDISCLOUD_URL);
-		console.log('What do you want to talk about...?', 'listening on: http://127.0.0.1:'+process.env.PORT);
+	server.start(function () {
+		require('./lib/chat').init(server.listener, function(){
+			console.log('REDISCLOUD_URL:', process.env.REDISCLOUD_URL);
+			console.log('Feeling Chatty?', 'listening on: http://127.0.0.1:'+process.env.PORT);
+		});
 	});
+	
 });
-
 module.exports = server;

--- a/test/server.js
+++ b/test/server.js
@@ -42,6 +42,6 @@ test(file +" Teardown > End Redis Connection & Stop Hapi Server", function(t) {
   decache('../lib/load_messages'); // uncache redis con  - - - - \\
   decache('../lib/chat');
   t.equal(chat.sub.connected, false);
-  server.stop();
+  server.stop(function(){});
   t.end();
 });


### PR DESCRIPTION
+ Updates dependencies
+ Adds [inert](https://www.npmjs.com/package/inert) plugin for static file serving.
+ Adds `PORT` environment variable to `test` & `coverage` script in `package.json` to address https://github.com/dwyl/hapi-socketio-redis-chat-example/issues/32 raised by @rjmk 

No change in *functionality*.