### PR TITLE
Fixed socket.io URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <script src="https://code.jquery.com/jquery-1.11.3.js"></script>
     <script src="https://cdn.rawgit.com/ScottHamper/Cookies/1.2.1/dist/cookies.min.js">
     </script>
-    <script src="https://cdn.socket.io/socket.io-1.3.5.js"></script>
+    <script src="http://cdn.socket.io/socket.io-1.3.5.js"></script>
     <script src="/client.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <script src="https://code.jquery.com/jquery-1.11.3.js"></script>
     <script src="https://cdn.rawgit.com/ScottHamper/Cookies/1.2.1/dist/cookies.min.js">
     </script>
-    <script src="http://cdn.socket.io/socket.io-1.3.5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.6/socket.io.min.js"></script>
     <script src="/client.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Socket.io's ssl isn't working ( NET::ERR_CERT_DATE_INVALID when going to the URL) and since the script link is broken and the demo doesn't work. Changing the https into http fixes that. Perhaps don't use a CDN for this as a permanent fix?