### PR TITLE
Improved mobile layout for smaller devices

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -43,8 +43,8 @@ $(document).ready(function () {
     var msg = JSON.parse(message);
     var html = '<li class=\'row\'>';
 
-    html += '<span class=\'name\'>' + msg.n + '</span>';
     html += '<small class=\'time\'>' + getTime(msg.t) + ' </small>';
+    html += '<span class=\'name\'>' + msg.n + '</span>';
     html += '<p class=\'msg\'>' + msg.m + '</p>';
     html += '</li>';
     $('#messages').append(html);  // append to list

--- a/lib/client.js
+++ b/lib/client.js
@@ -43,9 +43,9 @@ $(document).ready(function () {
     var msg = JSON.parse(message);
     var html = '<li class=\'row\'>';
 
+    html += '<span class=\'name\'>' + msg.n + '</span>';
     html += '<small class=\'time\'>' + getTime(msg.t) + ' </small>';
-    html += '<span class=\'name\'>' + msg.n + ': </span>';
-    html += '<span class=\'msg\'>' + msg.m + '</span>';
+    html += '<p class=\'msg\'>' + msg.m + '</p>';
     html += '</li>';
     $('#messages').append(html);  // append to list
   }

--- a/style.css
+++ b/style.css
@@ -13,9 +13,9 @@
   box-sizing: inherit;
 }
 
-body { 
-  font: 1.5em Helvetica, Arial; 
-  height: 100%; 
+body {
+  font: 1.5em Helvetica, Arial;
+  height: 100%;
   padding-bottom: 2.3em;
   overflow:auto;
 }
@@ -27,54 +27,56 @@ body {
 ================================*/
 form {
   background: #2c3e50;
-  height: 2.3em; 
+  height: 2.3em;
   width: 100%;
+  display: flex;
   padding: 3px;
   position: fixed;
   bottom: 0;
   margin: 0;
 }
 
-  form input { 
+  form input {
     border: 0;
     font-size: 1em;
     /*height: 2px;*/
     height: 2em;
-    width: 85%;
+    min-width: 70%;
+    flex: 1;
     padding:0.5em;
     margin-right: .5%;
   }
-  
-  form button { 
+
+  form button {
     background: #27ae60;
     border: none;
     color: white;
     font-size: 1em;
     height: 2em;
-    width: 14%;
-    padding: 10px; 
+    padding: 10px;
   }
-  
+
 /*==============================
   #JOINING-CHAT-STRAPLINE
-================================*/  
+================================*/
 
 #joiners {
   background-color:#2c3e50;
   color: white;
-  height: 2em;
   opacity:0.9;
-  padding: 0.5em 0 1em 2em;
   z-index: 3;
+  font-size: 1em;
+  text-align: center;
+  padding: 0.5em;
 }
 
 #joined  { color: #40d47e; }
-  
+
 
 
 /*==============================
   #MESSAGES-WINDOW
-================================*/    
+================================*/
 #messages {
   list-style-type: none;
   margin: 0;
@@ -83,11 +85,42 @@ form {
 }
 
   #messages li { padding: 5px 10px; }
-    
+
     #messages li:nth-child(odd) { background: #eee; }
 
 
 /* == Individual messages == */
-.time { color: #2c3e50; }
+.time { color: #9c9c9c; }
 
-.name { color: #2980b9; }
+.name {
+  color: #2980b9;
+  margin-right: 0.8em;
+}
+
+.name,
+.time {
+  font-size: 0.7em;
+}
+
+/*==============================
+  MEDIA QUERIES
+================================*/
+
+@media only screen and (min-width: 768px) {
+
+  .name {
+    font-size: 1em;
+  }
+
+  .name,
+  .time {
+    font-size: .8em;
+  }
+
+  #joiners {
+    height: 2em;
+    font-size: 1.5em;
+    padding: 0.5em 0 1em 2em;
+    text-align: left;
+  }
+}


### PR DESCRIPTION
This pull request addresses Issue https://github.com/dwyl/hapi-socketio-redis-chat-example/issues/31 and includes:
- Additional media queries for better support of smaller mobile devices.
- Rearranged message name, time, text order in individual messages.

Small Device
![mobile-small](https://cloud.githubusercontent.com/assets/4642404/21400820/dba57dea-c77f-11e6-93c8-670910c8a096.png)

Medium Device
![mobile-med](https://cloud.githubusercontent.com/assets/4642404/21400824/e19db906-c77f-11e6-81d5-97c371b5f650.png)


