### PR TITLE
Fix overflow on long names

### DIFF
--- a/style.css
+++ b/style.css
@@ -68,6 +68,7 @@ form {
   font-size: 1em;
   text-align: center;
   padding: 0.5em;
+  word-wrap: break-word;
 }
 
 #joined  { color: #40d47e; }
@@ -95,6 +96,7 @@ form {
 .name {
   color: #2980b9;
   margin-right: 0.8em;
+  word-wrap: break-word;
 }
 
 .name,


### PR DESCRIPTION
This PR addresses [Issue 46](https://github.com/dwyl/hapi-socketio-redis-chat-example/issues/46) by adding the `word-break: break-word` css attribute to the `name` and `joiners` classes.

Before Fix:
![long_name_overflow](https://cloud.githubusercontent.com/assets/4642404/21487939/e63bb704-cba5-11e6-9f2f-56fdf90ac681.png)

With Fix:
![wordwrap_fix](https://cloud.githubusercontent.com/assets/4642404/21487941/eb0a763a-cba5-11e6-8997-f5b81c023fd7.png)



