### PR TITLE
updates dependencies to working versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "hapi-error": "^1.7.0",
     "inert": "^4.2.0",
     "redis-connection": "^5.0.0",
-    "socket.io": "^2.0.1",
-    "socket.io-client": "^2.0.1"
+    "socket.io": "^1.7.3",
+    "socket.io-client": "^2.0.3"
   },
   "devDependencies": {
     "decache": "^4.1.0",


### PR DESCRIPTION
as said in #87
App not working with `v2.0.1` for `socket.io` and `socket.io-client` so versions changed to `1.7.3` and `2.0.3` respectively. 